### PR TITLE
Add commit_on_success kwarg to managed()

### DIFF
--- a/alchemytools/context.py
+++ b/alchemytools/context.py
@@ -3,13 +3,14 @@ from callback import Callback
 
 
 @contextmanager
-def managed(sessionClass, auto_flush=False, auto_commit=False, callback=None):
+def managed(sessionClass, auto_flush=False, auto_commit=False, callback=None, commit_on_success=True):
     session = sessionClass()
     session.autoflush = auto_flush
     session.autocommit = auto_commit
     try:
         yield session
-        session.commit()
+        if commit_on_success:
+            session.commit()
     except:
         session.rollback()
         if isinstance(callback, Callback):

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -58,12 +58,21 @@ class ManagedTest(unittest.TestCase):
         with managed(MySession, auto_commit=True) as s:
             assert s.autocommit == True
 
-    def test_commit_after_yield(self):
+    def test_commit_after_yield_when_commit_on_success_is_default(self):
         real_session = mock.Mock()
         self.mock_session.return_value = real_session
         with managed(self.mock_session):
             pass
         assert 1 == real_session.commit.call_count
+
+
+    def test_dont_commit_after_yield_when_commit_on_success_is_false(self):
+        real_session = mock.Mock()
+        self.mock_session.return_value = real_session
+        with managed(self.mock_session, commit_on_success=False):
+            pass
+        assert 0 == real_session.commit.call_count
+
 
     def test_close_after_yield(self):
         real_session = mock.Mock()


### PR DESCRIPTION
This removes the `commit_on_success` context manager stub and adds its funcionality to `managed` as a kwarg.
