### PR TITLE
Use full imports

### DIFF
--- a/alchemytools/context.py
+++ b/alchemytools/context.py
@@ -1,5 +1,4 @@
-from contextlib import contextmanager
-from callback import Callback
+from alchemytools.callback import Callback
 
 
 class managed(object):


### PR DESCRIPTION
I was getting this error when trying to `from alchemytools.context import managed`:
```
Traceback (most recent call last):
  File "tests/test_persistence.py", line 4, in <module>
    from alchemytools.context import managed
  File "/home/etandel/.virtualenvs/tioeliastanoov/lib/python3.5/site-packages/alchemytools/context.py", line 2, in <module>
    from callback import Callback
ImportError: No module named 'callback'
```

So I fixed it by changed the relative import to a full import.